### PR TITLE
Fixed label extraction

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -168,21 +168,26 @@ jobs:
           # Manual trigger - use input value
           version_type="${{ github.event.inputs.version_type }}"
         else
-          # PR trigger - determine from labels
-          pr_labels="${{ join(github.event.pull_request.labels.*.name, ' ') }}"
-
-          # Debug: Print all labels
-          echo "All PR labels: '$pr_labels'"
+          # Push trigger
+          version_type="minor"  # default
           
-          # Check for release labels
-          if echo "$pr_labels" | grep -q "release: major"; then
-            version_type="major"
-          elif echo "$pr_labels" | grep -q "release: minor"; then
-            version_type="minor"
-          elif echo "$pr_labels" | grep -q "release: patch"; then
-            version_type="patch"
-          else
-            version_type="minor"  # default
+          # Try to get PR number from context
+          pr_number="${{ github.context.issue.number }}"
+          echo "PR number from context: '$pr_number'"
+          
+          if [ -n "$pr_number" ] && [ "$pr_number" != "null" ]; then
+            # Get PR labels using GitHub API
+            pr_labels=$(gh pr view "$pr_number" --json labels --jq '.labels[].name' | tr '\n' ' ')
+            echo "PR labels from API: '$pr_labels'"
+            
+            # Check for release labels
+            if echo "$pr_labels" | grep -q "release: major"; then
+              version_type="major"
+            elif echo "$pr_labels" | grep -q "release: minor"; then
+              version_type="minor"
+            elif echo "$pr_labels" | grep -q "release: patch"; then
+              version_type="patch"
+            fi
           fi
         fi
         


### PR DESCRIPTION
A follow up to #6 and #7.

Turned out that during release the PR labels weren't available through `github.event.pull_request.labels.*.name` so now we are switching to extracting them from the PR another way.